### PR TITLE
RQLY-767 fix: pass correct requestDetails as data for advanced filters

### DIFF
--- a/src/components/proxy-middleware/helpers/rule_processor_helper.js
+++ b/src/components/proxy-middleware/helpers/rule_processor_helper.js
@@ -97,6 +97,7 @@ class RuleProcessorHelper {
     const rule_action = rule_processor.process({
       rule,
       requestURL: this.request_data.request_url,
+      details: this.request_data
     });
     return rule_action;
   };
@@ -113,7 +114,7 @@ class RuleProcessorHelper {
     const rule_action = rule_processor.process({
       rule,
       requestURL: this.request_data.request_url,
-      details: { requestData },
+      details: { ...this.request_data , requestData },
     });
     return rule_action;
   };
@@ -130,7 +131,7 @@ class RuleProcessorHelper {
     const rule_action = rule_processor.process({
       rule,
       requestURL: this.request_data.request_url,
-      details: { requestData },
+      details: { ...this.request_data , requestData },
     });
     return rule_action;
   };
@@ -170,6 +171,7 @@ class RuleProcessorHelper {
       payload: {
         requestOrigin: getRequestOrigin(),
       },
+      details: this.request_data
     });
 
     return rule_action;
@@ -214,6 +216,7 @@ class RuleProcessorHelper {
       payload: {
         requestOrigin: getRequestOrigin(),
       },
+      details: this.request_data
     });
 
     return rule_action;
@@ -241,6 +244,7 @@ class RuleProcessorHelper {
       requestURL: this.request_data.request_url,
       rule,
       originalRequestHeaders: originalRequestHeadersObjectKeysValuePairs,
+      details: this.request_data
     });
 
     return rule_action;


### PR DESCRIPTION
To implement requestly/requestly-desktop-app#12 processors need to receive extra request data