### PR TITLE
RQLY-774 fix: websocket binary frame detection

### DIFF
--- a/src/lib/proxy/lib/proxy.ts
+++ b/src/lib/proxy/lib/proxy.ts
@@ -1189,7 +1189,7 @@ Proxy.prototype._onWebSocketFrame = function (
   type,
   fromServer,
   data,
-  flags
+  isBinary
 ) {
   var self = this;
   async.forEach(
@@ -1221,7 +1221,7 @@ Proxy.prototype._onWebSocketFrame = function (
       if (destWebSocket.readyState === WebSocket.OPEN) {
         switch (type) {
           case "message":
-            destWebSocket.send(data, flags);
+            destWebSocket.send(data, { binary: isBinary });
             break;
           case "ping":
             destWebSocket.ping(data, flags, false);


### PR DESCRIPTION
fixes https://github.com/requestly/requestly/issues/232
Socket messages can be of two types - text and binary. The proxy's web socket server must specify the type of message it is sending ahead.

References:
1. https://github.com/websockets/ws/commit/e173423c180dc1e4e6ee8938d9e4376a7a8b9757
2. https://stackoverflow.com/a/60244286/11565176

> Note: This does not fix the issue with secure WebSockets (`wss`)