### PR TITLE
feat: non existent domain support

### DIFF
--- a/src/components/proxy-middleware/helpers/proxy_ctx_helper.js
+++ b/src/components/proxy-middleware/helpers/proxy_ctx_helper.js
@@ -20,7 +20,7 @@ export const get_original_request_headers = (ctx) => {
 
 export const get_original_response_headers = (ctx) => {
   // TODO: This needs to be fetched from ctx.clientToProxy headers
-  return ctx.serverToProxyResponse.headers;
+  return ctx?.serverToProxyResponse?.headers || {};
 };
 
 export const is_request_preflight = (ctx) => {

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -133,7 +133,6 @@ class ProxyMiddlewareManager {
       );
 
       ctx.onError(async function (ctx, err, kind, callback) {
-        // console.log("onError", ctx, err, kind);
         // Should only modify response body & headers
         ctx.rq_response_body = "" + kind + ": " + err, "utf8";
         const { action_result_objs, continue_request } = await rules_middleware.on_response(ctx);
@@ -141,8 +140,7 @@ class ProxyMiddlewareManager {
         // Only modify response if any modify_response action is applied
         const modifyResponseActionExist = action_result_objs.some((action_result_obj) => action_result_obj?.action?.action === "modify_response")
 
-        if(action_result_objs.length > 0 && modifyResponseActionExist) {
-          // ctx.proxyToClientResponse.writeHead(404, "Proxy Error").end("TESTING 101");
+        if(modifyResponseActionExist) {
           const statusCode = ctx.rq_response_status_code || 404;
           const responseHeaders = getResponseHeaders(ctx) || {}
           ctx.proxyToClientResponse.writeHead(

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_header_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_header_processor.js
@@ -6,6 +6,7 @@ const process_modify_header_action = (action, ctx) => {
   const allowed_handlers = [
     PROXY_HANDLER_TYPE.ON_REQUEST,
     PROXY_HANDLER_TYPE.ON_RESPONSE,
+    PROXY_HANDLER_TYPE.ON_ERROR,
   ];
 
   if (!allowed_handlers.includes(ctx.currentHandler)) {
@@ -14,7 +15,7 @@ const process_modify_header_action = (action, ctx) => {
 
   if (ctx.currentHandler == PROXY_HANDLER_TYPE.ON_REQUEST) {
     modify_request_headers(action, ctx);
-  } else if (ctx.currentHandler == PROXY_HANDLER_TYPE.ON_RESPONSE) {
+  } else if (ctx.currentHandler === PROXY_HANDLER_TYPE.ON_RESPONSE || ctx.currentHandler === PROXY_HANDLER_TYPE.ON_ERROR) {
     modify_response_headers(action, ctx);
   }
   return build_action_processor_response(action, true);
@@ -35,6 +36,8 @@ const modify_request_headers = (action, ctx) => {
 };
 
 const modify_response_headers = (action, ctx) => {
+  ctx.serverToProxyResponse = ctx.serverToProxyResponse || {}
+  ctx.serverToProxyResponse.headers = ctx.serverToProxyResponse.headers || {}
   // {"header1":"val1", "header2":"val2"}
   const originalResponseHeadersObject = ctx.serverToProxyResponse.headers;
   //  ["header1","header2"]

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
@@ -84,7 +84,7 @@ const modify_response_using_code = async (action, ctx) => {
         : null,
       response: ctx?.rq_response_body,
       url: get_request_url(ctx),
-      responseType: ctx?.serverToProxyResponse?.headers && ctx?.serverToProxyResponse?.headers["content-type"],
+      responseType: ctx?.serverToProxyResponse?.headers?.["content-type"],
       requestHeaders: ctx.clientToProxyRequest.headers,
       requestData: parseJsonBody(ctx.rq?.final_request?.body) || null,
     };

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
@@ -13,7 +13,7 @@ import { getFunctionFromString } from "../../../../utils";
 const { types } = require("util");
 
 const process_modify_response_action = async (action, ctx) => {
-  const allowed_handlers = [PROXY_HANDLER_TYPE.ON_RESPONSE_END];
+  const allowed_handlers = [PROXY_HANDLER_TYPE.ON_RESPONSE_END, PROXY_HANDLER_TYPE.ON_ERROR];
 
   if (!allowed_handlers.includes(ctx.currentHandler)) {
     return build_action_processor_response(action, false);
@@ -82,9 +82,9 @@ const modify_response_using_code = async (action, ctx) => {
           ? ctx.clientToProxyRequest.method
           : null
         : null,
-      response: ctx.rq_response_body,
+      response: ctx?.rq_response_body,
       url: get_request_url(ctx),
-      responseType: ctx.serverToProxyResponse.headers["content-type"],
+      responseType: ctx?.serverToProxyResponse?.headers && ctx?.serverToProxyResponse?.headers["content-type"],
       requestHeaders: ctx.clientToProxyRequest.headers,
       requestData: parseJsonBody(ctx.rq?.final_request?.body) || null,
     };

--- a/src/lib/proxy/lib/proxy.ts
+++ b/src/lib/proxy/lib/proxy.ts
@@ -641,7 +641,7 @@ Proxy.prototype._onError = function (kind, ctx, err) {
   }
 
   async.forEach(
-    this.onErrorHandlers.concat(ctx && ctx.onErrorHandlers),
+    this.onErrorHandlers.concat(ctx?.onErrorHandlers || []),
     function (fn, callback) {
       if (fn) {
         return fn(ctx, err, kind, callback);


### PR DESCRIPTION
Add support to modify response for Non Existent Domains (DNS check fails)
- Modify headers
- Modify Response
    - Static Modification
    - Programmatic Modification (Fetch from other url and then return response)

> Default Status Code returned when `Response rule` applied = 404