### PR TITLE
chore: add application/manifest+json as intercepted content type

### DIFF
--- a/src/components/proxy-middleware/constants.js
+++ b/src/components/proxy-middleware/constants.js
@@ -18,4 +18,5 @@ export const RQ_INTERCEPTED_CONTENT_TYPES = [
   "text/css",
   "application/css",
   "application/json",
+  "application/manifest+json"
 ];


### PR DESCRIPTION
`application/manifest+json` is the officially _recommended_ content type proposed by the spec around app manifest, specifically under the [media type registration section](https://www.w3.org/TR/appmanifest/#media-type-registration)

A good discussion around this can be found here - https://github.com/w3c/manifest/issues/689