### PR TITLE
feat: duration upto networkEvent logging + fix: startDateTime of HAR

### DIFF
--- a/src/components/proxy-middleware/helpers/ctx_rq_namespace.ts
+++ b/src/components/proxy-middleware/helpers/ctx_rq_namespace.ts
@@ -29,11 +29,14 @@ class CtxRQNamespace {
   original_response: Partial<RQResponse>
   final_request: Partial<finalRequest> 
   final_response: Partial<RQResponse>
+
+  startTimestamp: number
   
   consoleLogs: ConsoleLog[]
   
 
   constructor() {
+    this.startTimestamp = Date.now();
     this.original_request = {
       // method: ctx.clientToProxyRequest.method,
       // path: ctx.clientToProxyRequest.url,
@@ -82,7 +85,8 @@ class CtxRQNamespace {
       this.final_response.status_code,
       this.final_response.body,
       this.final_response.headers,
-      this.final_request.query_params
+      this.final_request.query_params,
+      this.startTimestamp
     )
   }
 
@@ -99,7 +103,8 @@ class CtxRQNamespace {
       this.original_response.status_code,
       this.original_response.body,
       this.original_response.headers,
-      this.original_request.query_params
+      this.original_request.query_params,
+      this.startTimestamp
     )
   }
 
@@ -131,7 +136,6 @@ class CtxRQNamespace {
     status_code = null,
     headers = null,
     body = null,
-    query_params = null,
   }) => {
     if (headers) {
       this.original_response.headers = { ...headers };

--- a/src/components/proxy-middleware/helpers/harObectCreator.js
+++ b/src/components/proxy-middleware/helpers/harObectCreator.js
@@ -128,23 +128,23 @@ export const createRequestHarObject = (
 };
 
 
-export const createHar = (requestHeaders, method, protocol, host, path, requestBody, responseStatusCode, response, responseHeaders, requestParams) => {
+export const createHar = (requestHeaders, method, protocol, host, path, requestBody, responseStatusCode, response, responseHeaders, requestParams, requestStartTime) => {
   return {
     "log": {
       "version" : "1.2",
       "creator" : {},
       "browser" : {},
       "pages": [],
-      "entries": [createHarEntry(requestHeaders, method, protocol, host, path, requestBody, responseStatusCode, response, responseHeaders, requestParams)],
+      "entries": [createHarEntry(requestHeaders, method, protocol, host, path, requestBody, responseStatusCode, response, responseHeaders, requestParams, requestStartTime)],
       "comment": "" 
     }
   };
 }
 
-export const createHarEntry = (requestHeaders, method, protocol, host, path, requestBody, responseStatusCode, response, responseHeaders, requestParams) => {
+export const createHarEntry = (requestHeaders, method, protocol, host, path, requestBody, responseStatusCode, response, responseHeaders, requestParams, requestStartTime) => {
   return {
       // "pageref": "page_0",
-      "startedDateTime": new Date().toISOString(),
+      "startedDateTime": new Date(requestStartTime).toISOString(),
       // "time": 50,
       "request": createHarRequest(requestHeaders, method, protocol, host, path, requestBody, requestParams),
       "response": createHarResponse(responseStatusCode, response, responseHeaders),

--- a/src/components/proxy-middleware/middlewares/logger_middleware.ts
+++ b/src/components/proxy-middleware/middlewares/logger_middleware.ts
@@ -66,7 +66,8 @@ class LoggerMiddleware {
     let eventHar = ctx.rq.getHar()
     eventHar = addCustomDetailsToHarEntries(eventHar, {
       id: ctx.uuid,
-      consoleLogs: ctx.rq.consoleLogs
+      consoleLogs: ctx.rq.consoleLogs,
+      duration: Date.now() - ctx.rq.startTimestamp
     })
 
     // todo: domain and app check


### PR DESCRIPTION
before this, `startDateTime` used to show time at which log was sent. It is supposed to signify start time of request.

`duration` is now part of the custom `_RQ` key of HAREntry. It is the ms time since start of request to logging of network event