### PR TITLE
fix: parse response body for all intercepted requests

### DIFF
--- a/src/components/proxy-middleware/helpers/http_helpers.js
+++ b/src/components/proxy-middleware/helpers/http_helpers.js
@@ -30,8 +30,24 @@ export const bodyParser = (contentTypeHeader, buffer) => {
       }
     });
   }
-
   return str_buffer;
+
+
+  /* 
+   FOLLOWING IS HOW API CLIENT PARSES THE BODY 
+   much simpler than above, but requires thorough testing
+  */
+  // // todo: add support for other content types
+  // let parsedResponse;
+  // if (contentTypeHeader?.includes("image/")) {
+  //   const raw = Buffer.from(buffer).toString("base64");
+  //   parsedResponse = `data:${contentTypeHeader};base64,${raw}`;
+  // } else {
+  //   parsedResponse = new TextDecoder().decode(buffer);
+  // }
+
+  // return parsedResponse;
+
 };
 
 export const getContentType = (contentTypeHeader) => {

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -224,6 +224,11 @@ class ProxyMiddlewareManager {
         ctx.rq_response_body = body;
         ctx.rq_parsed_response_body = parsedBody;
         ctx.rq_response_status_code = getResponseStatusCode(ctx);
+
+        if (RQ_INTERCEPTED_CONTENT_TYPES.includes(contentType) && parsedBody) {
+          ctx.rq_response_body = parsedBody;
+          ctx.rq.set_original_response({ body: parsedBody });
+        }
         const { action_result_objs, continue_request } = await rules_middleware.on_response_end(ctx);
 
 
@@ -254,8 +259,7 @@ class ProxyMiddlewareManager {
       // Remove headers that may conflict
       delete getRequestHeaders(ctx)["content-length"];
 
-      const { action_result_objs, continue_request } =
-        await rules_middleware.on_request(ctx);
+      const { action_result_objs, continue_request } = await rules_middleware.on_request(ctx);
 
       ctx.rq.set_final_request(get_request_options(ctx));
       // TODO: Removing this log for now. Will add this when support is added for upsert in firebase logs.


### PR DESCRIPTION
Does not solve the encoding issue, but stops sending the raw buffers in the parsed body.