### PR TITLE
feat: ProxyConfig now also takes optional paramter onCARegenerated 

### DIFF
--- a/dist/lib/proxy/lib/ca.d.ts
+++ b/dist/lib/proxy/lib/ca.d.ts
@@ -1,5 +1,6 @@
 export = CA;
 declare class CA {
+    onCARegenerated(callback: any): void;
     randomSerialNumber(): string;
     generateCA(callback: any): void;
     loadCA(callback: any): void;

--- a/dist/lib/proxy/lib/proxy.d.ts
+++ b/dist/lib/proxy/lib/proxy.d.ts
@@ -16,7 +16,7 @@ declare var WebSocket: {
 };
 declare var url: any;
 declare var semaphore: any;
-declare var ca: any;
+declare var CA: any;
 declare var Sentry: any;
 declare const checkInvalidHeaderChar: any;
 declare const debug: any;

--- a/dist/rq-proxy.js
+++ b/dist/rq-proxy.js
@@ -13,6 +13,9 @@ class RQProxy {
             console.log(proxyConfig);
             // @ts-ignore
             this.proxy = new proxy_1.default();
+            if (proxyConfig.onCARegenerated) {
+                this.proxy.onCARegenerated(proxyConfig.onCARegenerated);
+            }
             // console.log(this.proxy);
             this.proxy.listen({
                 port: proxyConfig.port,

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -1,7 +1,9 @@
 export interface ProxyConfig {
+    [x: string]: any;
     port: Number;
     certPath: String;
     rootCertPath: String;
+    onCARegenerated?: Function;
 }
 export interface Rule {
     id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.1.24",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/requestly-proxy",
-      "version": "1.1.24",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.1.24",
+  "version": "1.2.0",
   "description": "Proxy that gives superpowers to all the Requestly clients",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/proxy/index.d.ts
+++ b/src/lib/proxy/index.d.ts
@@ -69,6 +69,7 @@ declare namespace HttpMitmProxy {
         }
       ) => void
     ): void;
+    onCARegenerated(callback: () => void): void;
 
     //undocumented helpers
     onConnect(

--- a/src/lib/proxy/lib/ca.js
+++ b/src/lib/proxy/lib/ca.js
@@ -135,7 +135,13 @@ var ServerExtensions = [
   },
 ];
 
-var CA = function () {};
+var CA = function () {
+  this.onCARegenerationCallbacks = []
+};
+
+CA.prototype.onCARegenerated = function (callback) {
+  this.onCARegenerationCallbacks.push(callback);
+};
 
 CA.create = function (caFolder, callback) {
   var ca = new CA();
@@ -175,6 +181,8 @@ CA.create = function (caFolder, callback) {
       return callback(null, ca);
     }
   );
+
+  return ca;
 };
 
 CA.prototype.randomSerialNumber = function () {
@@ -212,6 +220,20 @@ CA.prototype.generateCA = function (callback) {
     cert.sign(keys.privateKey, Forge.md.sha256.create());
     self.CAcert = cert;
     self.CAkeys = keys;
+
+    // delete all the keys and certs in the folders, first
+    // so that previously generated keys and certs are not used
+    async.parallel([
+      ...FS.readdirSync(self.certsFolder).map((file) => {
+        return () => FS.unlinkSync(path.join(self.certsFolder, file));
+      }),
+      ...FS.readdirSync(self.keysFolder).map((file) => {
+        return () => FS.unlinkSync(path.join(self.keysFolder, file));
+      }),
+    ], (err) => {
+      console.debug("Error while deleting existing certs during CA regeneration: ", err);
+    })
+
     async.parallel(
       [
         FS.writeFile.bind(
@@ -228,11 +250,13 @@ CA.prototype.generateCA = function (callback) {
           null,
           path.join(self.keysFolder, "ca.public.key"),
           pki.publicKeyToPem(keys.publicKey)
-        ),
+        ), 
       ],
       callback
     );
-  });
+
+    this.onCARegenerationCallbacks.forEach((callback) => callback(path.join(self.certsFolder, "ca.pem"))) 
+  }.bind(self));
 };
 
 CA.prototype.loadCA = function (callback) {

--- a/src/rq-proxy.ts
+++ b/src/rq-proxy.ts
@@ -25,6 +25,9 @@ class RQProxy {
         console.log(proxyConfig);
         // @ts-ignore
         this.proxy = new Proxy();
+        if(proxyConfig.onCARegenerated) {
+            this.proxy.onCARegenerated(proxyConfig.onCARegenerated)
+        }
         // console.log(this.proxy);
         this.proxy.listen(
             {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,9 @@
 export interface ProxyConfig {
+    [x: string]: any;
     port: Number;
     certPath: String;
     rootCertPath: String;
+    onCARegenerated?: Function;
 }
 
 export interface Rule {


### PR DESCRIPTION
To register callbacks for RootCA regeneration. 

These changes also make sure that certificates and keys generated using the old CA are deleted