### PR TITLE
fix: request body chunks not being passed ahead to the server

### DIFF
--- a/src/lib/proxy/lib/proxy.ts
+++ b/src/lib/proxy/lib/proxy.ts
@@ -1374,7 +1374,7 @@ Proxy.prototype._onRequestData = function (ctx, chunk, callback) {
         if (err) {
           return callback(err);
         }
-        chunk = newChunk;
+
         return callback(null, newChunk);
       });
     },


### PR DESCRIPTION
fixes: https://github.com/requestly/requestly/issues/271

> tldr; `newChunk` overrides `chunk` to `null`. Due `chunk` being closure in the final callback of async, always null is sent ahead.

The [`iteratee`](https://caolan.github.io/async/v3/docs.html#each) in [`Proxy.prototype._onRequestData`](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1367-L1388) introduces `newChunk` that is always `null`. The abstract function that introduces this is the `callback` function invoked [here](https://github.com/requestly/requestly-proxy/blob/ba3aa6d476c3919c13fad2b21296b4d615c27ca7/src/components/proxy-middleware/index.js#L173) _hence verifies_ `newChunk` is always `null`.

Inside [`Proxy.prototype._onRequestData`](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1367-L1388) , the [final callback](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1381-L1386) is called at the end of each chunk. 
 
<details>
  <summary><i>Expand this to understand why that final callback is called after every chunk, and not the entire body</i></summary>


You will need to understand `async.forEach` (which under the hood is actually just `async.each`) from [the docs](https://caolan.github.io/async/v3/docs.html#each)

but the basics are that the first argument is an iterable, second is a function that runs on each element of the iterable (in parallel, i.e. not in order), and third is a final callback function which receives an error (_if any_)

<details>
<summary><i>all this is too complicated for our usecase</i></summary>

because after careful evaluation [this.onRequestDataHandlers.concat(ctx.onRequestDataHandlers)](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1371)

is basically just an array of one with the single element being [our custom handler](https://github.com/requestly/requestly-proxy/blob/ba3aa6d476c3919c13fad2b21296b4d615c27ca7/src/components/proxy-middleware/index.js#L169-L174)
  
</details>

and `proxy._onRequestData` is triggered inside the [custom Request filter](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1101-L1140) via which [all the request body is piped](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1043-L1047) (_again over complicated for no reason. `ctx.requestFilters` is basically `[new ProxyFinalRequestFilter(self, ctx)]`_)

<details>
<summary>why only the request body, and not the rest of the request?</summary>

Its quite obvious once you read through [`makeProxyToServerRequest`](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1033), [`proxyToServerRequestComplete`](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1052) and this part of [`Proxy.prototype._onHttpServerRequest`](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1001-L1030)


</details>
</details>

since `chunk` is closured. The final callback gets `null`as the value (since we always give `newChunk` as `null`).

Hence no post body is ever streamed forward that has more than one chunk, (_I believe the first chunk get's handled before the closured new `chunk` value; i.e. null; persists for the final callback_). 

Hence this isn't that commonly observed (plus we have wayyy fewer POST requests that reliably work with our proxy)


<details>
<summary><strong>Why does this same thing not affect response</strong></summary>

Inside [`Proxy.prototype._onResponseData`](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1429-L1450) you'll notice it's the exact same code but if you make the same change there things start to break.

even [ProxyFinalResponseFilter](https://github.com/requestly/requestly-proxy/blob/master/src/lib/proxy/lib/proxy.ts#L1143-L1184) is a lot like `ProxyFinalRequestFilter`

but the write there get's handled inside the [custom handler that we have written](https://github.com/requestly/requestly-proxy/blob/ba3aa6d476c3919c13fad2b21296b4d615c27ca7/src/components/proxy-middleware/index.js#L217-L257) (_see [this line](https://github.com/requestly/requestly-proxy/blob/ba3aa6d476c3919c13fad2b21296b4d615c27ca7/src/components/proxy-middleware/index.js#L242)_)

So how the chunks are handled internally isn't a problem. since the callback is taking care of the transfer. 

</details>