### PR TITLE
feat: parse port from onConnect handler

### DIFF
--- a/src/components/proxy-middleware/middlewares/logger_middleware.js
+++ b/src/components/proxy-middleware/middlewares/logger_middleware.js
@@ -1,6 +1,6 @@
 import { cloneDeep } from "lodash";
 import HTTPSnippet from "httpsnippet";
-import { get_success_actions_from_action_results } from "../rule_action_processor/utils";
+import { get_success_actions_from_action_results, getHost } from "../rule_action_processor/utils";
 import { createHar } from "../helpers/harObectCreator";
 const url = require("url");
 
@@ -21,6 +21,7 @@ class LoggerMiddleware {
         indent: " ",
       });
     } catch (err) {
+      // FIX-ME: this always fails on local
       console.error(`LoggerMiddleware.generate_curl_from_har Error: ${err}`);
     }
     return requestCurl;
@@ -79,7 +80,7 @@ class LoggerMiddleware {
         ctx.rq.final_request.headers,
         ctx.rq.final_request.method,
         protocol,
-        ctx.rq.final_request.host,
+        getHost(ctx),
         ctx.rq.final_request.path,
         ctx.rq.final_request.body,
         ctx.rq.final_response.status_code,

--- a/src/components/proxy-middleware/rule_action_processor/utils.js
+++ b/src/components/proxy-middleware/rule_action_processor/utils.js
@@ -40,3 +40,22 @@ export const get_success_actions_from_action_results = (
 
   return success_action_results_objs.map((obj) => obj.action);
 };
+
+function isLocalHost(host) {
+  return host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0";
+}
+
+function isHTTPport(port) {
+  return port === "80" || port === "443";
+}
+
+export const getHost = (ctx) => {
+  const finalHost = ctx.rq.final_request.host;
+  const originalURLOnConnect = ctx._originalUrl_;
+  const originalPort = originalURLOnConnect?.split(":")?.[1] || originalURLOnConnect?.split(":")?.[1] || null;
+  if(isLocalHost(finalHost) && originalPort && !isHTTPport(originalPort)) {
+    return `${finalHost}:${originalPort}`;
+  } else {
+    return finalHost
+  }
+}

--- a/src/lib/proxy/lib/proxy.ts
+++ b/src/lib/proxy/lib/proxy.ts
@@ -373,6 +373,7 @@ Proxy.prototype._onSocketError = function (socketDescription, err) {
 
 Proxy.prototype._onHttpServerConnect = function (req, socket, head) {
   var self = this;
+  self._originalUrl_ = req.url;
 
   socket.on("error", self._onSocketError.bind(self, "CLIENT_TO_PROXY_SOCKET"));
 
@@ -877,6 +878,7 @@ Proxy.prototype._onHttpServerRequest = function (
 ) {
   var self = this;
   var ctx = {
+    _originalUrl_: self._originalUrl_,
     uuid: uuidv4(),
     isSSL: isSSL,
     connectRequest:


### PR DESCRIPTION
- sets the _originalUrl_ attribute on ctx
- updates logger code to send port in case of local and non-http port