### PR TITLE
feat: global state inside proxy and dynamic request and response rules

### DIFF
--- a/src/components/interfaces/state.ts
+++ b/src/components/interfaces/state.ts
@@ -1,0 +1,4 @@
+export default interface IInitialState extends Record<string, any> {
+    sharedState?: Record<string, any>;
+    variables?: Record<string, any>;
+}

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -29,6 +29,7 @@ export const MIDDLEWARE_TYPE = {
   RULES: "RULES",
   LOGGER: "LOGGER",
   SSL_CERT: "SSL_CERT",
+  GLOBAL_STATE: "GLOBAL_STATE", // SEEMS UNUSUED, BUT ADDING FOR COMPLETENESS
 };
 
 class ProxyMiddlewareManager {
@@ -37,7 +38,8 @@ class ProxyMiddlewareManager {
     proxyConfig,
     rulesHelper,
     loggerService,
-    sslConfigFetcher
+    sslConfigFetcher,
+    customGlobalState
   ) {
     /*
     {
@@ -57,8 +59,10 @@ class ProxyMiddlewareManager {
 
     this.sslConfigFetcher = sslConfigFetcher;
     // this.sslProxyingManager = new SSLProxyingManager(sslConfigFetcher);
+    this.customGlobalState = customGlobalState;
   }
 
+  /* NOT USEFUL */
   init_config = (config = {}) => {
     Object.keys(MIDDLEWARE_TYPE).map((middleware_key) => {
       this.config[middleware_key] =
@@ -131,6 +135,8 @@ class ProxyMiddlewareManager {
         ctx,
         this.rulesHelper
       );
+      
+      ctx.customGlobalState = this.customGlobalState;
 
       ctx.onError(async function (ctx, err, kind, callback) {
         // Should only modify response body & headers

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -39,7 +39,6 @@ class ProxyMiddlewareManager {
     rulesHelper,
     loggerService,
     sslConfigFetcher,
-    customGlobalState
   ) {
     /*
     {
@@ -59,7 +58,6 @@ class ProxyMiddlewareManager {
 
     this.sslConfigFetcher = sslConfigFetcher;
     // this.sslProxyingManager = new SSLProxyingManager(sslConfigFetcher);
-    this.customGlobalState = customGlobalState;
   }
 
   /* NOT USEFUL */
@@ -135,8 +133,6 @@ class ProxyMiddlewareManager {
         ctx,
         this.rulesHelper
       );
-      
-      ctx.customGlobalState = this.customGlobalState;
 
       ctx.onError(async function (ctx, err, kind, callback) {
         // Should only modify response body & headers

--- a/src/components/proxy-middleware/middlewares/state.d.ts
+++ b/src/components/proxy-middleware/middlewares/state.d.ts
@@ -1,0 +1,17 @@
+import IInitialGlobalState from '../../interfaces/state';
+
+declare class GlobalState {
+    private state: IInitialGlobalState;
+    constructor(initialState?: IInitialGlobalState);
+
+    setSharedState(newSharedState: Record<string, any>): void;
+    getSharedStateRef(): Record<string, any>;
+    getSharedStateCopy(): Record<string, any>;
+    setVariables(newVariables: Record<string, any>): void;
+    getVariablesRef(): Record<string, any>;
+    getVariablesCopy(): Record<string, any>;
+}
+
+declare const ProxyGlobal: GlobalState;
+
+export { GlobalState as default, ProxyGlobal };

--- a/src/components/proxy-middleware/middlewares/state.ts
+++ b/src/components/proxy-middleware/middlewares/state.ts
@@ -1,13 +1,16 @@
 import {cloneDeep} from 'lodash';
-import IInitialState from '../../interfaces/state';
 
-export default class State {
-    protected state: IInitialState;
-    constructor(initialState?: IInitialState) {
+interface IState extends Record<string, any> {
+    sharedState?: Record<string, any>;
+    variables?: Record<string, any>;
+}
+
+export class State {
+    private state: IState;
+    constructor(sharedState: Record<string, any>, envVars: Record<string, any>) {
         this.state = {
-            variables: {},
-            sharedState: {},
-            ...initialState
+            variables: envVars,
+            sharedState,
         };
     }
 
@@ -33,5 +36,24 @@ export default class State {
 
     getVariablesCopy() {
         return cloneDeep(this.state.variables);
+    }
+}
+
+export default class GlobalStateProvider {
+    private static instance: State
+    static initInstance(sharedState: Record<string, any> = {}, envVars: Record<string, any> = {}) {
+        if (!GlobalStateProvider.instance) {
+            GlobalStateProvider.instance = new State(sharedState ?? {}, envVars ?? {});
+        }
+
+        return GlobalStateProvider.instance;
+    }
+
+    static getInstance() {
+        if (!GlobalStateProvider.instance) {
+          console.error("[GlobalStateProvider]", "Init first");
+        }
+
+        return GlobalStateProvider.instance;
     }
 }

--- a/src/components/proxy-middleware/middlewares/state.ts
+++ b/src/components/proxy-middleware/middlewares/state.ts
@@ -1,0 +1,37 @@
+import {cloneDeep} from 'lodash';
+import IInitialState from '../../interfaces/state';
+
+export default class State {
+    protected state: IInitialState;
+    constructor(initialState?: IInitialState) {
+        this.state = {
+            variables: {},
+            sharedState: {},
+            ...initialState
+        };
+    }
+
+    setSharedState(newSharedState: Record<string, any>) {
+        this.state.sharedState = newSharedState;
+    }
+
+    getSharedStateRef() {
+        return this.state.sharedState;
+    }
+
+    getSharedStateCopy() {
+        return cloneDeep(this.state.sharedState);
+    }
+
+    setVariables(newVariables: Record<string, any>) {
+        this.state.variables = newVariables;
+    }
+
+    getVariablesRef() {
+        return this.state.variables;
+    }
+
+    getVariablesCopy() {
+        return cloneDeep(this.state.variables);
+    }
+}

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
@@ -5,7 +5,7 @@ import {
 } from "@requestly/requestly-core";
 import { get_request_url } from "../../helpers/proxy_ctx_helper";
 import { build_action_processor_response } from "../utils";
-import { getFunctionFromString } from "../../../../utils";
+import { executeUserFunction, getFunctionFromString } from "../../../../utils";
 
 const process_modify_request_action = (action, ctx) => {
   const allowed_handlers = [PROXY_HANDLER_TYPE.ON_REQUEST_END];
@@ -34,7 +34,7 @@ const modify_request_using_code = async (action, ctx) => {
   let userFunction = null;
   let sharedState = ctx.customGlobalState.getSharedStateCopy();
   try {
-    const res = getFunctionFromString(action.response,sharedState);
+    const res = getFunctionFromString(action.request,sharedState);
     userFunction = res.func;
     sharedState = res.sharedState;
   } catch (error) {
@@ -76,7 +76,7 @@ const modify_request_using_code = async (action, ctx) => {
       /*Do nothing -- could not parse body as JSON */
     }
 
-    finalResponse = await executeUserFunction(ctx, userFunction, args, sharedState)
+    finalRequest = await executeUserFunction(ctx, userFunction, args, sharedState)
 
     if (finalRequest && typeof finalRequest === "string") {
       return modify_request(ctx, finalRequest);

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
@@ -32,7 +32,7 @@ const modify_request = (ctx, new_req) => {
 
 const modify_request_using_code = async (action, ctx) => {
   let userFunction = null;
-  let sharedState = ctx.customGlobalState.getSharedStateCopy();
+  let sharedState = GlobalStateProvider.getInstance().getSharedStateCopy();
   try {
     const res = getFunctionFromString(action.request,sharedState);
     userFunction = res.func;

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
@@ -5,10 +5,7 @@ import {
 } from "@requestly/requestly-core";
 import { get_request_url } from "../../helpers/proxy_ctx_helper";
 import { build_action_processor_response } from "../utils";
-import ConsoleCapture from "capture-console-logs";
 import { getFunctionFromString } from "../../../../utils";
-
-const { types } = require("util");
 
 const process_modify_request_action = (action, ctx) => {
   const allowed_handlers = [PROXY_HANDLER_TYPE.ON_REQUEST_END];
@@ -35,8 +32,11 @@ const modify_request = (ctx, new_req) => {
 
 const modify_request_using_code = async (action, ctx) => {
   let userFunction = null;
+  let sharedState = ctx.customGlobalState.getSharedStateCopy();
   try {
-    userFunction = getFunctionFromString(action.request);
+    const res = getFunctionFromString(action.response,sharedState);
+    userFunction = res.func;
+    sharedState = res.sharedState;
   } catch (error) {
     // User has provided an invalid function
     return modify_request(
@@ -76,24 +76,7 @@ const modify_request_using_code = async (action, ctx) => {
       /*Do nothing -- could not parse body as JSON */
     }
 
-    const consoleCapture = new ConsoleCapture()
-    consoleCapture.start(true)
-
-    finalRequest = userFunction(args);
-
-    if (types.isPromise(finalRequest)) {
-      finalRequest = await finalRequest;
-    }
-
-    consoleCapture.stop()
-    const consoleLogs = consoleCapture.getCaptures()
-
-    ctx.rq.consoleLogs.push(...consoleLogs)
-
-    const isRequestJSON = !!args.bodyAsJson;
-    if (typeof finalRequest === "object" && isRequestJSON) {
-      finalRequest = JSON.stringify(finalRequest);
-    }
+    finalResponse = await executeUserFunction(ctx, userFunction, args, sharedState)
 
     if (finalRequest && typeof finalRequest === "string") {
       return modify_request(ctx, finalRequest);

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_request_processor.js
@@ -32,11 +32,8 @@ const modify_request = (ctx, new_req) => {
 
 const modify_request_using_code = async (action, ctx) => {
   let userFunction = null;
-  let sharedState = GlobalStateProvider.getInstance().getSharedStateCopy();
   try {
-    const res = getFunctionFromString(action.request,sharedState);
-    userFunction = res.func;
-    sharedState = res.sharedState;
+    userFunction = getFunctionFromString(action.request);
   } catch (error) {
     // User has provided an invalid function
     return modify_request(
@@ -76,7 +73,7 @@ const modify_request_using_code = async (action, ctx) => {
       /*Do nothing -- could not parse body as JSON */
     }
 
-    finalRequest = await executeUserFunction(ctx, userFunction, args, sharedState)
+    finalRequest = await executeUserFunction(ctx, userFunction, args)
 
     if (finalRequest && typeof finalRequest === "string") {
       return modify_request(ctx, finalRequest);

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
@@ -9,6 +9,7 @@ import fs from "fs";
 import { getContentType, parseJsonBody } from "../../helpers/http_helpers";
 import { executeUserFunction, getFunctionFromString } from "../../../../utils";
 import { RQ_INTERCEPTED_CONTENT_TYPES } from "../../constants";
+import GlobalStateProvider from "../../middlewares/state";
 
 const process_modify_response_action = async (action, ctx) => {
   const allowed_handlers = [PROXY_HANDLER_TYPE.ON_REQUEST,PROXY_HANDLER_TYPE.ON_RESPONSE_END, PROXY_HANDLER_TYPE.ON_ERROR];
@@ -98,7 +99,7 @@ const modify_response_using_local = (action, ctx) => {
 
 const modify_response_using_code = async (action, ctx) => {
   let userFunction = null;
-  let sharedState = ctx.customGlobalState.getSharedStateCopy();
+  let sharedState = GlobalStateProvider.getInstance().getSharedStateCopy();
   // let sharedState = ProxyGlobal.getSharedStateCopy();
   try {
     const res = getFunctionFromString(action.response,sharedState);

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
@@ -7,11 +7,8 @@ import { getResponseContentTypeHeader, getResponseHeaders, get_request_url } fro
 import { build_action_processor_response, build_post_process_data } from "../utils";
 import fs from "fs";
 import { getContentType, parseJsonBody } from "../../helpers/http_helpers";
-import ConsoleCapture from "capture-console-logs";
-import { getFunctionFromString } from "../../../../utils";
+import { executeUserFunction, getFunctionFromString } from "../../../../utils";
 import { RQ_INTERCEPTED_CONTENT_TYPES } from "../../constants";
-
-const { types } = require("util");
 
 const process_modify_response_action = async (action, ctx) => {
   const allowed_handlers = [PROXY_HANDLER_TYPE.ON_REQUEST,PROXY_HANDLER_TYPE.ON_RESPONSE_END, PROXY_HANDLER_TYPE.ON_ERROR];
@@ -101,8 +98,12 @@ const modify_response_using_local = (action, ctx) => {
 
 const modify_response_using_code = async (action, ctx) => {
   let userFunction = null;
+  let sharedState = ctx.customGlobalState.getSharedStateCopy();
+  // let sharedState = ProxyGlobal.getSharedStateCopy();
   try {
-    userFunction = getFunctionFromString(action.response);
+    const res = getFunctionFromString(action.response,sharedState);
+    userFunction = res.func;
+    sharedState = res.sharedState;
   } catch (error) {
     // User has provided an invalid function
     return modify_response(
@@ -144,23 +145,7 @@ const modify_response_using_code = async (action, ctx) => {
       /*Do nothing -- could not parse body as JSON */
     }
 
-    const consoleCapture = new ConsoleCapture()
-    consoleCapture.start(true)
-
-    finalResponse = userFunction(args);
-
-    if (types.isPromise(finalResponse)) {
-      finalResponse = await finalResponse;
-    }
-
-    consoleCapture.stop()
-    const consoleLogs = consoleCapture.getCaptures()
-    
-    ctx.rq.consoleLogs.push(...consoleLogs)
-
-    if (typeof finalResponse === "object") {
-      finalResponse = JSON.stringify(finalResponse);
-    }
+    finalResponse = await executeUserFunction(ctx, userFunction, args, sharedState)
 
     if (finalResponse && typeof finalResponse === "string") {
       return modify_response(ctx, finalResponse, action.statusCode);

--- a/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
+++ b/src/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
@@ -9,7 +9,6 @@ import fs from "fs";
 import { getContentType, parseJsonBody } from "../../helpers/http_helpers";
 import { executeUserFunction, getFunctionFromString } from "../../../../utils";
 import { RQ_INTERCEPTED_CONTENT_TYPES } from "../../constants";
-import GlobalStateProvider from "../../middlewares/state";
 
 const process_modify_response_action = async (action, ctx) => {
   const allowed_handlers = [PROXY_HANDLER_TYPE.ON_REQUEST,PROXY_HANDLER_TYPE.ON_RESPONSE_END, PROXY_HANDLER_TYPE.ON_ERROR];
@@ -99,12 +98,8 @@ const modify_response_using_local = (action, ctx) => {
 
 const modify_response_using_code = async (action, ctx) => {
   let userFunction = null;
-  let sharedState = GlobalStateProvider.getInstance().getSharedStateCopy();
-  // let sharedState = ProxyGlobal.getSharedStateCopy();
   try {
-    const res = getFunctionFromString(action.response,sharedState);
-    userFunction = res.func;
-    sharedState = res.sharedState;
+    userFunction = getFunctionFromString(action.response);
   } catch (error) {
     // User has provided an invalid function
     return modify_response(
@@ -146,7 +141,7 @@ const modify_response_using_code = async (action, ctx) => {
       /*Do nothing -- could not parse body as JSON */
     }
 
-    finalResponse = await executeUserFunction(ctx, userFunction, args, sharedState)
+    finalResponse = await executeUserFunction(ctx, action.response, args)
 
     if (finalResponse && typeof finalResponse === "string") {
       return modify_response(ctx, finalResponse, action.statusCode);

--- a/src/rq-proxy-provider.ts
+++ b/src/rq-proxy-provider.ts
@@ -8,8 +8,8 @@ class RQProxyProvider {
     static rqProxyInstance:any = null;
 
     // TODO: rulesDataSource can be static here
-    static createInstance = (proxyConfig: ProxyConfig, rulesDataSource: IRulesDataSource, loggerService: ILoggerService, initialCustomState?: IInitialState) => {
-        RQProxyProvider.rqProxyInstance = new RQProxy(proxyConfig, rulesDataSource, loggerService, initialCustomState);
+    static createInstance = (proxyConfig: ProxyConfig, rulesDataSource: IRulesDataSource, loggerService: ILoggerService, initialGlobalState?: IInitialState) => {
+        RQProxyProvider.rqProxyInstance = new RQProxy(proxyConfig, rulesDataSource, loggerService, initialGlobalState);
     }
 
     static getInstance = (): RQProxy => {

--- a/src/rq-proxy-provider.ts
+++ b/src/rq-proxy-provider.ts
@@ -1,14 +1,15 @@
 import RQProxy from "./rq-proxy";
 import ILoggerService from "./components/interfaces/logger-service";
 import IRulesDataSource from "./components/interfaces/rules-data-source";
+import IInitialState from "./components/interfaces/state";
 import { ProxyConfig } from "./types";
 
 class RQProxyProvider {
     static rqProxyInstance:any = null;
 
     // TODO: rulesDataSource can be static here
-    static createInstance = (proxyConfig: ProxyConfig, rulesDataSource: IRulesDataSource, loggerService: ILoggerService) => {
-        RQProxyProvider.rqProxyInstance = new RQProxy(proxyConfig, rulesDataSource, loggerService);
+    static createInstance = (proxyConfig: ProxyConfig, rulesDataSource: IRulesDataSource, loggerService: ILoggerService, initialCustomState?: IInitialState) => {
+        RQProxyProvider.rqProxyInstance = new RQProxy(proxyConfig, rulesDataSource, loggerService, initialCustomState);
     }
 
     static getInstance = (): RQProxy => {

--- a/src/rq-proxy.ts
+++ b/src/rq-proxy.ts
@@ -4,6 +4,8 @@ import { ProxyConfig } from "./types";
 import RulesHelper from "./utils/helpers/rules-helper";
 import ProxyMiddlewareManager from "./components/proxy-middleware";
 import ILoggerService from "./components/interfaces/logger-service";
+import IInitialState from "./components/interfaces/state";
+import State from "./components/proxy-middleware/middlewares/state";
 
 
 class RQProxy {
@@ -12,12 +14,19 @@ class RQProxy {
 
     rulesHelper: RulesHelper;
     loggerService: ILoggerService;
+    customGlobalState: State;
 
-    constructor(proxyConfig: ProxyConfig, rulesDataSource: IRulesDataSource, loggerService: ILoggerService) {
+    constructor(
+        proxyConfig: ProxyConfig, 
+        rulesDataSource: IRulesDataSource, 
+        loggerService: ILoggerService,
+        initialCustomState?: IInitialState
+    ) {
         this.initProxy(proxyConfig);
 
         this.rulesHelper = new RulesHelper(rulesDataSource);
         this.loggerService = loggerService;
+        this.customGlobalState = new State(initialCustomState);
     }
 
     initProxy = (proxyConfig: ProxyConfig) => {
@@ -41,7 +50,7 @@ class RQProxy {
                     console.log(err);
                 } else {
                     console.log("Proxy Started");
-                    this.proxyMiddlewareManager = new ProxyMiddlewareManager(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null);
+                    this.proxyMiddlewareManager = new ProxyMiddlewareManager(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null, this.customGlobalState);
                     this.proxyMiddlewareManager.init();
                 }
             }

--- a/src/rq-proxy.ts
+++ b/src/rq-proxy.ts
@@ -5,7 +5,7 @@ import RulesHelper from "./utils/helpers/rules-helper";
 import ProxyMiddlewareManager from "./components/proxy-middleware";
 import ILoggerService from "./components/interfaces/logger-service";
 import IInitialState from "./components/interfaces/state";
-import State from "./components/proxy-middleware/middlewares/state";
+import GlobalStateProvider, {State} from "./components/proxy-middleware/middlewares/state";
 
 
 class RQProxy {
@@ -26,7 +26,7 @@ class RQProxy {
 
         this.rulesHelper = new RulesHelper(rulesDataSource);
         this.loggerService = loggerService;
-        this.globalState = new State(initialGlobalState);
+        this.globalState = GlobalStateProvider.initInstance(initialGlobalState?.sharedState ?? {}, initialGlobalState?.variables ?? {});
     }
 
     initProxy = (proxyConfig: ProxyConfig) => {
@@ -50,7 +50,7 @@ class RQProxy {
                     console.log(err);
                 } else {
                     console.log("Proxy Started");
-                    this.proxyMiddlewareManager = new ProxyMiddlewareManager(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null, this.globalState);
+                    this.proxyMiddlewareManager = new ProxyMiddlewareManager(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null);
                     this.proxyMiddlewareManager.init();
                 }
             }

--- a/src/rq-proxy.ts
+++ b/src/rq-proxy.ts
@@ -14,19 +14,19 @@ class RQProxy {
 
     rulesHelper: RulesHelper;
     loggerService: ILoggerService;
-    customGlobalState: State;
+    globalState: State;
 
     constructor(
         proxyConfig: ProxyConfig, 
         rulesDataSource: IRulesDataSource, 
         loggerService: ILoggerService,
-        initialCustomState?: IInitialState
+        initialGlobalState?: IInitialState
     ) {
         this.initProxy(proxyConfig);
 
         this.rulesHelper = new RulesHelper(rulesDataSource);
         this.loggerService = loggerService;
-        this.customGlobalState = new State(initialCustomState);
+        this.globalState = new State(initialGlobalState);
     }
 
     initProxy = (proxyConfig: ProxyConfig) => {
@@ -50,7 +50,7 @@ class RQProxy {
                     console.log(err);
                 } else {
                     console.log("Proxy Started");
-                    this.proxyMiddlewareManager = new ProxyMiddlewareManager(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null, this.customGlobalState);
+                    this.proxyMiddlewareManager = new ProxyMiddlewareManager(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null, this.globalState);
                     this.proxyMiddlewareManager.init();
                 }
             }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { types } from "util";
 import ConsoleCapture from "capture-console-logs";
+import GlobalStateProvider from "../components/proxy-middleware/middlewares/state";
 
 // currently expecting sharedState to be copy NOT a reference. For use with the function below
 export const getFunctionFromString = function (functionStringEscaped, sharedState = {}) {
@@ -32,8 +33,7 @@ export async function executeUserFunction(ctx, generatedFunction, args, sharedSt
      * 
      * But we are using it here to ensure that the logic is obvious when we read the code.
      */
-    console.log("DBG: customGlobalState", JSON.stringify(ctx.customGlobalState, null, 2));
-    ctx.customGlobalState?.setSharedState(sharedState);
+    GlobalStateProvider.getInstance().setSharedState(sharedState);
 
     if (typeof finalResponse === "object") {
         finalResponse = JSON.stringify(finalResponse);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,15 +2,21 @@ import { types } from "util";
 import ConsoleCapture from "capture-console-logs";
 import GlobalStateProvider from "../components/proxy-middleware/middlewares/state";
 
-// currently expecting sharedState to be copy NOT a reference. For use with the function below
-export const getFunctionFromString = function (functionStringEscaped, sharedState = {}) {
-    return new Function("sharedState", `return { func: ${functionStringEscaped}, sharedState}`)(sharedState);
+// Only used for verification now. For execution, we regenerate the function in executeUserFunction with the sharedState
+export const getFunctionFromString = function (functionStringEscaped) {
+    return new Function(`return ${functionStringEscaped}`)();
 };
 
 
-// to execute the function generated above
-export async function executeUserFunction(ctx, generatedFunction, args, sharedState) {
+/* Expects that the functionString has already been validated to be representing a proper function */
+export async function executeUserFunction(ctx, functionString: string, args) {
+    const generateFunctionWithSharedState = function (functionStringEscaped, sharedState = {}) {
+      return new Function("$sharedState", `return { func: ${functionStringEscaped}, sharedState: $sharedState}`)(sharedState);
+    };
 
+    const sharedState = GlobalStateProvider.getInstance().getSharedStateCopy();
+    const {func: generatedFunction, sharedState: updatedSharedStateRef} = generateFunctionWithSharedState(functionString, sharedState);
+    
     const consoleCapture = new ConsoleCapture()
     consoleCapture.start(true)
 
@@ -31,9 +37,9 @@ export async function executeUserFunction(ctx, generatedFunction, args, sharedSt
      * Because then the function gets a reference to the global states,
      * and any changes made inside the userFunction will directly be reflected there.
      * 
-     * But we are using it here to ensure that the logic is obvious when we read the code.
+     * But we are using it here to make the data flow obvious as we read this code.
      */
-    GlobalStateProvider.getInstance().setSharedState(sharedState);
+    GlobalStateProvider.getInstance().setSharedState(updatedSharedStateRef);
 
     if (typeof finalResponse === "object") {
         finalResponse = JSON.stringify(finalResponse);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,43 @@
-export const getFunctionFromString = function (functionStringEscaped) {
-    return new Function("return " + functionStringEscaped)();
+import { types } from "util";
+import ConsoleCapture from "capture-console-logs";
+
+// currently expecting sharedState to be copy NOT a reference. For use with the function below
+export const getFunctionFromString = function (functionStringEscaped, sharedState = {}) {
+    return new Function("sharedState", `return { func: ${functionStringEscaped}, sharedState}`)(sharedState);
 };
+
+
+// to execute the function generated above
+export async function executeUserFunction(ctx, generatedFunction, args, sharedState) {
+
+    const consoleCapture = new ConsoleCapture()
+    consoleCapture.start(true)
+
+    let finalResponse = generatedFunction(args);
+
+    if (types.isPromise(finalResponse)) {
+      finalResponse = await finalResponse;
+    }
+
+    consoleCapture.stop()
+    const consoleLogs = consoleCapture.getCaptures()
+    
+    ctx.rq.consoleLogs.push(...consoleLogs)
+
+    /**
+     * If we use GlobalState.getSharedStateRef instead of GlobalState.getSharedStateCopy
+     * then this update is completely unnecessary. 
+     * Because then the function gets a reference to the global states,
+     * and any changes made inside the userFunction will directly be reflected there.
+     * 
+     * But we are using it here to ensure that the logic is obvious when we read the code.
+     */
+    console.log("DBG: customGlobalState", JSON.stringify(ctx.customGlobalState, null, 2));
+    ctx.customGlobalState?.setSharedState(sharedState);
+
+    if (typeof finalResponse === "object") {
+        finalResponse = JSON.stringify(finalResponse);
+      }
+
+    return finalResponse;
+}


### PR DESCRIPTION
## What is global state
initializer object has iterface:
https://github.com/requestly/requestly-proxy/blob/e1f9e79fbd63b2872d6639464eaba257a5208a26/src/components/interfaces/state.ts#L1-L4

the internal `.state` attribute of class `State` is not meant to be accessed externally. Should always have getters/setters for top level keys.

I have also made separate _ref_ and _copy_ getters, in case we want to change the implementation later
> this detail is important to avoid closures while using this state across several request execution context

## Added attributes/arguments to initializer:
- `ProxyProvider.createInstance` takes the `intialGlobalState` argument to define intial value of global state
- this is passed to `RQProxy` -> takes new argument and initializes the state object.
  - Intial state object based on the passed `intialGlobalState`
  - stores it as an attribute in `globalState`
  - storing it here, _and not further down_, to make it [easily accessible by module consumer](https://github.com/requestly/requestly-desktop-app/blob/af7cb691875637f4266459b40c55fd72ad239c04/src/renderer/actions/initEventHandlers.js#L67-L68)
- Passes the new `RQProxy.globalState` to `ProxyMiddlewareManager` _(new argument in constructor - `customGlobalState`)_
- Inside `ProxyMiddlewareManager` this reference to the state object gets added to `ctx.customGlobalState` for each request execution context. **THEY ALL REFERENCE THE SAME STATE OBJECT**

## How is state injected to rule
the `Function` constructor [allows passing arguments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function#parameters) to the top-level generator function. So far, this generator function would returns the user's custom function. hence previously `new Function("return " + functionString)` would result in 

```javascript
function anon(){ 
    return modifyResponse(args){
        /* user's custom code */
    }
}
```

these changes now produce this:

```javascript
function anon(sharedState){ 
    return modifyResponse(args){
        /* user's custom code that now might use the sharedState variable */
    }
}
```
hence the generated `userFunction` can hold a reference to the global `sharedState`

_P.S. I have also abstracted out the custom function execution logic, since it was duplicated as is across the two rule types_
