### PR TITLE
chore: version bump to v1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/requestly-proxy",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Proxy that gives superpowers to all the Requestly clients",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- removes the file upload fix since it was causing regression errors https://github.com/requestly/requestly-proxy/pull/48
- fixes the content type header of the ssl certificate served from the middleware https://github.com/requestly/requestly-proxy/pull/49