### PR TITLE
chore: bump version to v1.3.7

### DIFF
--- a/dist/components/proxy-middleware/rule_action_processor/utils.d.ts
+++ b/dist/components/proxy-middleware/rule_action_processor/utils.d.ts
@@ -9,3 +9,4 @@ export function build_post_process_data(status_code: any, headers: any, body: an
     body: any;
 };
 export function get_success_actions_from_action_results(action_result_objs?: any[]): any[];
+export function get_file_contents(file_path: any): string;

--- a/dist/components/proxy-middleware/rule_action_processor/utils.js
+++ b/dist/components/proxy-middleware/rule_action_processor/utils.js
@@ -1,6 +1,10 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.get_success_actions_from_action_results = exports.build_post_process_data = exports.build_action_processor_response = void 0;
+exports.get_file_contents = exports.get_success_actions_from_action_results = exports.build_post_process_data = exports.build_action_processor_response = void 0;
+const fs_1 = __importDefault(require("fs"));
 const build_action_processor_response = (action, success = false, post_process_data = null) => {
     let resp = {
         action: action,
@@ -31,3 +35,7 @@ const get_success_actions_from_action_results = (action_result_objs = []) => {
     return success_action_results_objs.map((obj) => obj.action);
 };
 exports.get_success_actions_from_action_results = get_success_actions_from_action_results;
+const get_file_contents = (file_path) => {
+    return fs_1.default.readFileSync(action.response, "utf-8");
+};
+exports.get_file_contents = get_file_contents;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/requestly-proxy",
-      "version": "1.3.5",
+      "version": "1.3.7",
       "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "^1.1.0",
@@ -220,9 +220,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Proxy that gives superpowers to all the Requestly clients",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
releasing support for `serveWithoutRequest` for modify response processor when handling modification with local file https://github.com/requestly/requestly-proxy/pull/59