### PR TITLE
chore: bump version to v1.3.9

### DIFF
--- a/dist/components/proxy-middleware/index.js
+++ b/dist/components/proxy-middleware/index.js
@@ -96,7 +96,12 @@ class ProxyMiddlewareManager {
                             headers: responseHeaders,
                             body: ctx.rq_response_body,
                         });
-                        logger_middleware.send_network_log(ctx, rules_middleware.action_result_objs, requestly_core_1.CONSTANTS.REQUEST_STATE.COMPLETE);
+                        if (!ctx.rq.request_finished) {
+                            logger_middleware.send_network_log(ctx, rules_middleware.action_result_objs, requestly_core_1.CONSTANTS.REQUEST_STATE.COMPLETE);
+                        }
+                        else {
+                            console.log("Expected Error after early termination of request: ", err);
+                        }
                     }
                     return callback();
                 });
@@ -119,6 +124,10 @@ class ProxyMiddlewareManager {
                     if (parsedBody && constants_1.RQ_INTERCEPTED_CONTENT_TYPES.includes(contentType)) {
                         // Do modifications, if any
                         const { action_result_objs, continue_request } = await rules_middleware.on_request_end(ctx);
+                        if (!continue_request) {
+                            logger_middleware.send_network_log(ctx, rules_middleware.action_result_objs, requestly_core_1.CONSTANTS.REQUEST_STATE.COMPLETE);
+                            return;
+                        }
                     }
                     // Use the updated request
                     ctx.proxyToServerRequest.write(ctx.rq_request_body);

--- a/dist/components/proxy-middleware/middlewares/rules_middleware.js
+++ b/dist/components/proxy-middleware/middlewares/rules_middleware.js
@@ -78,6 +78,7 @@ class RulesMiddleware {
                 return [];
             }
             this._update_request_data({ request_body: ctx.rq.get_json_request_body() });
+            this.on_request_actions = this._process_rules();
             const { action_result_objs, continue_request } = await this.rule_action_processor.process_actions(this.on_request_actions, ctx);
             this._update_action_result_objs(action_result_objs);
             return { action_result_objs, continue_request };

--- a/dist/components/proxy-middleware/rule_action_processor/index.js
+++ b/dist/components/proxy-middleware/rule_action_processor/index.js
@@ -45,6 +45,7 @@ class RuleActionProcessor {
                     body = JSON.stringify(body);
                 }
                 ctx.proxyToClientResponse.writeHead(status_code, headers).end(body);
+                ctx.rq.request_finished = true;
                 ctx.rq.set_final_response({
                     status_code: status_code,
                     headers: headers,

--- a/dist/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
+++ b/dist/components/proxy-middleware/rule_action_processor/processors/modify_response_processor.js
@@ -8,11 +8,17 @@ const http_helpers_1 = require("../../helpers/http_helpers");
 const utils_2 = require("../../../../utils");
 const constants_1 = require("../../constants");
 const process_modify_response_action = async (action, ctx) => {
-    const allowed_handlers = [proxy_1.PROXY_HANDLER_TYPE.ON_REQUEST, proxy_1.PROXY_HANDLER_TYPE.ON_RESPONSE_END, proxy_1.PROXY_HANDLER_TYPE.ON_ERROR];
+    const allowed_handlers = [
+        proxy_1.PROXY_HANDLER_TYPE.ON_REQUEST,
+        proxy_1.PROXY_HANDLER_TYPE.ON_REQUEST_END,
+        proxy_1.PROXY_HANDLER_TYPE.ON_RESPONSE_END,
+        proxy_1.PROXY_HANDLER_TYPE.ON_ERROR
+    ];
     if (!allowed_handlers.includes(ctx.currentHandler)) {
         return (0, utils_1.build_action_processor_response)(action, false);
     }
-    if (ctx.currentHandler === proxy_1.PROXY_HANDLER_TYPE.ON_REQUEST) {
+    if (ctx.currentHandler === proxy_1.PROXY_HANDLER_TYPE.ON_REQUEST ||
+        ctx.currentHandler === proxy_1.PROXY_HANDLER_TYPE.ON_REQUEST_END) {
         if (action.serveWithoutRequest) {
             let contentType, finalBody;
             if (action.responseType === requestly_core_1.CONSTANTS.RESPONSE_BODY_TYPES.LOCAL_FILE) {
@@ -41,7 +47,13 @@ const process_modify_response_action = async (action, ctx) => {
                 contentType = "text/plain";
             }
             const status = action.statusCode || 200;
-            const finalHeaders = { "Content-Type": contentType };
+            const finalHeaders = {
+                "content-type": contentType,
+                "access-control-allow-origin": "*",
+                "access-control-allow-methods": "*",
+                "access-control-allow-headers": "*",
+                "access-control-allow-credentials": "true",
+            };
             modify_response(ctx, finalBody, status);
             return (0, utils_1.build_action_processor_response)(action, true, (0, utils_1.build_post_process_data)(status, finalHeaders, finalBody));
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/requestly-proxy",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/requestly-proxy",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Proxy that gives superpowers to all the Requestly clients",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- rolling out fix for serve without hitting server for graphql requests