### PR TITLE
fix: support 204 in API Client via proxy

### DIFF
--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -287,10 +287,20 @@ class ProxyMiddlewareManager {
 
 
         const statusCode = ctx.rq_response_status_code || getResponseStatusCode(ctx);
+        const responseHeaders = getResponseHeaders(ctx);
+
+        // For 204/304/1xx, remove content headers to prevent errors
+        if (statusCode === 204 || statusCode === 304 || (statusCode >= 100 && statusCode < 200)) {
+          delete responseHeaders['content-length'];
+          delete responseHeaders['Content-Length'];
+          delete responseHeaders['transfer-encoding'];
+          delete responseHeaders['Transfer-Encoding'];
+        }
+
         ctx.proxyToClientResponse.writeHead(
           statusCode,
           http.STATUS_CODES[statusCode],
-          getResponseHeaders(ctx)
+          responseHeaders,
         );
 
         ctx.proxyToClientResponse.write(ctx.rq_response_body);


### PR DESCRIPTION
requestly-proxy works correctly for response status code 204. But when it is used along with axios, it leads to this failure `maxContentLength size of -1 exceeded`.

This happens because when server return 204, no `transfer-encoding` header should be present as per RFC. https://github.com/pallets/werkzeug/issues/2375#issue-1191508182