### PR TITLE
RQ-2425: verify upstream TLS by default (+ live toggle, clear cert errors)

### DIFF
--- a/dist/components/proxy-middleware/helpers/handleUnreachableAddress.d.ts
+++ b/dist/components/proxy-middleware/helpers/handleUnreachableAddress.d.ts
@@ -1,4 +1,12 @@
 export function isAddressUnreachableError(host: any): Promise<any>;
+export function isCertificateError(err: any): boolean;
+export function certErrorToken(code: any): "ERR_CERT_DATE_INVALID" | "ERR_CERT_COMMON_NAME_INVALID" | "ERR_CERT_REVOKED" | "ERR_CERT_AUTHORITY_INVALID";
+export function dataToServeCertErrorPage(host: any, code: any): {
+    status: number;
+    contentType: string;
+    errorToken: string;
+    body: string;
+};
 export function dataToServeUnreachablePage(host: any): {
     status: number;
     contentType: string;

--- a/dist/components/proxy-middleware/helpers/handleUnreachableAddress.js
+++ b/dist/components/proxy-middleware/helpers/handleUnreachableAddress.js
@@ -9,6 +9,16 @@ exports.certErrorToken = certErrorToken;
 exports.dataToServeCertErrorPage = dataToServeCertErrorPage;
 exports.dataToServeUnreachablePage = dataToServeUnreachablePage;
 const dns_1 = __importDefault(require("dns"));
+// Escape request-derived values before embedding them into the HTML error pages
+// so a crafted host/URL can't inject markup/script (reflected injection).
+function escapeHtml(value) {
+    return String(value === undefined || value === null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
 function isAddressUnreachableError(host) {
     return new Promise((resolve, reject) => {
         dns_1.default.lookup(host, (err, address) => {
@@ -69,6 +79,8 @@ function certErrorToken(code) {
 }
 function dataToServeCertErrorPage(host, code) {
     const token = certErrorToken(code);
+    const safeHost = escapeHtml(host);
+    const safeCode = escapeHtml(code);
     return {
         status: 502,
         contentType: 'text/html',
@@ -128,7 +140,7 @@ function dataToServeCertErrorPage(host, code) {
     <div class="container">
         <div class="sad-face">:(</div>
         <h1>This site's SSL certificate isn't trusted</h1>
-        <p>Requestly couldn't verify the TLS certificate of <strong>${host}</strong>${code ? ` (<code>${code}</code>)` : ''}.</p>
+        <p>Requestly couldn't verify the TLS certificate of <strong>${safeHost}</strong>${code ? ` (<code>${safeCode}</code>)` : ''}.</p>
         <p>If you trust this host, enable <strong>“Allow insecure SSL in proxy interceptor”</strong> in Requestly desktop settings and reload.</p>
         <p><strong>${token}</strong></p>
     </div>
@@ -190,7 +202,7 @@ function dataToServeUnreachablePage(host) {
     <div class="container">
         <div class="sad-face">:(</div>
         <h1>This site can’t be reached</h1>
-        <p>The webpage at <strong>${host}/</strong> might be temporarily down or it may have moved permanently to a new web address.</p>
+        <p>The webpage at <strong>${escapeHtml(host)}/</strong> might be temporarily down or it may have moved permanently to a new web address.</p>
         <p><strong>ERR_NAME_NOT_RESOLVED</strong></p>
     </div>
 </body>

--- a/dist/components/proxy-middleware/helpers/handleUnreachableAddress.js
+++ b/dist/components/proxy-middleware/helpers/handleUnreachableAddress.js
@@ -4,6 +4,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isAddressUnreachableError = isAddressUnreachableError;
+exports.isCertificateError = isCertificateError;
+exports.certErrorToken = certErrorToken;
+exports.dataToServeCertErrorPage = dataToServeCertErrorPage;
 exports.dataToServeUnreachablePage = dataToServeUnreachablePage;
 const dns_1 = __importDefault(require("dns"));
 function isAddressUnreachableError(host) {
@@ -22,6 +25,117 @@ function isAddressUnreachableError(host) {
             }
         });
     });
+}
+// RQ-2425: upstream TLS certificate verification failures. These surface when
+// "Allow insecure SSL in proxy interceptor" is OFF (the default) and the origin
+// presents an untrusted/expired/self-signed cert. Without this, such failures
+// were misreported as ERR_NAME_NOT_RESOLVED, which is confusing.
+const TLS_CERT_ERROR_CODES = new Set([
+    'CERT_HAS_EXPIRED',
+    'CERT_NOT_YET_VALID',
+    'DEPTH_ZERO_SELF_SIGNED_CERT',
+    'SELF_SIGNED_CERT_IN_CHAIN',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+    'UNABLE_TO_GET_ISSUER_CERT',
+    'CERT_UNTRUSTED',
+    'CERT_REVOKED',
+    'CERT_REJECTED',
+    'HOSTNAME_MISMATCH',
+    'ERR_TLS_CERT_ALTNAME_INVALID',
+]);
+function isCertificateError(err) {
+    if (!err)
+        return false;
+    if (err.code && TLS_CERT_ERROR_CODES.has(err.code))
+        return true;
+    const message = String((err && (err.message || err.reason)) || '');
+    return /\bcertificate\b/i.test(message) || /ERR_TLS_CERT/i.test(message);
+}
+// Maps a Node/OpenSSL cert error code to a Chrome-style token users recognise.
+function certErrorToken(code) {
+    switch (code) {
+        case 'CERT_HAS_EXPIRED':
+        case 'CERT_NOT_YET_VALID':
+            return 'ERR_CERT_DATE_INVALID';
+        case 'HOSTNAME_MISMATCH':
+        case 'ERR_TLS_CERT_ALTNAME_INVALID':
+            return 'ERR_CERT_COMMON_NAME_INVALID';
+        case 'CERT_REVOKED':
+            return 'ERR_CERT_REVOKED';
+        default:
+            return 'ERR_CERT_AUTHORITY_INVALID';
+    }
+}
+function dataToServeCertErrorPage(host, code) {
+    const token = certErrorToken(code);
+    return {
+        status: 502,
+        contentType: 'text/html',
+        errorToken: token,
+        body: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>${token}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+    <style>
+        body {
+            background-color: #f2f2f2;
+            color: #333;
+            font-family: 'Roboto', sans-serif;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 100px auto;
+            padding: 20px;
+            text-align: center;
+        }
+        .sad-face {
+            font-size: 80px;
+            margin-bottom: 20px;
+        }
+        h1 {
+            font-size: 24px;
+            font-weight: normal;
+            margin-bottom: 10px;
+        }
+        p {
+            font-size: 16px;
+            color: #666;
+        }
+        code {
+            background: #e8e8e8;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+        @media (max-width: 600px) {
+            .container {
+                margin-top: 50px;
+                padding: 10px;
+            }
+            .sad-face {
+                font-size: 60px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="sad-face">:(</div>
+        <h1>This site's SSL certificate isn't trusted</h1>
+        <p>Requestly couldn't verify the TLS certificate of <strong>${host}</strong>${code ? ` (<code>${code}</code>)` : ''}.</p>
+        <p>If you trust this host, enable <strong>“Allow insecure SSL in proxy interceptor”</strong> in Requestly desktop settings and reload.</p>
+        <p><strong>${token}</strong></p>
+    </div>
+</body>
+</html>
+        `.trim()
+    };
 }
 function dataToServeUnreachablePage(host) {
     return {

--- a/dist/components/proxy-middleware/index.d.ts
+++ b/dist/components/proxy-middleware/index.d.ts
@@ -14,6 +14,7 @@ declare class ProxyMiddlewareManager {
     rulesHelper: any;
     loggerService: any;
     sslConfigFetcher: any;
+    setAllowInsecureCerts: (value: any) => void;
     init_config: (config?: {}) => void;
     init: (config?: {}) => void;
     request_handler_idx: number;

--- a/dist/components/proxy-middleware/index.js
+++ b/dist/components/proxy-middleware/index.js
@@ -137,8 +137,16 @@ class ProxyMiddlewareManager {
                         try {
                             // Resolve against a clean hostname (headers.host minus any port), not
                             // the full request URL — dns.lookup() can't parse a URL and would
-                            // otherwise report every upstream error as ENOTFOUND.
-                            const hostname = (((_b = (_a = ctx.clientToProxyRequest) === null || _a === void 0 ? void 0 : _a.headers) === null || _b === void 0 ? void 0 : _b.host) || "").split(":")[0];
+                            // otherwise report every upstream error as ENOTFOUND. Parse via URL so
+                            // IPv6 literals (e.g. "[::1]:443") are handled correctly, not split on ":".
+                            const rawHost = ((_b = (_a = ctx.clientToProxyRequest) === null || _a === void 0 ? void 0 : _a.headers) === null || _b === void 0 ? void 0 : _b.host) || "";
+                            let hostname = rawHost;
+                            try {
+                                hostname = new URL(`http://${rawHost}`).hostname.replace(/^\[|\]$/g, "");
+                            }
+                            catch (e) {
+                                hostname = rawHost.replace(/:\d+$/, "");
+                            }
                             const isAddressUnreachable = await (0, handleUnreachableAddress_1.isAddressUnreachableError)(hostname);
                             if (isAddressUnreachable) {
                                 const { status, contentType, body } = (0, handleUnreachableAddress_1.dataToServeUnreachablePage)(host);

--- a/dist/components/proxy-middleware/index.js
+++ b/dist/components/proxy-middleware/index.js
@@ -29,6 +29,14 @@ exports.MIDDLEWARE_TYPE = {
 };
 class ProxyMiddlewareManager {
     constructor(proxy, proxyConfig, rulesHelper, loggerService, sslConfigFetcher) {
+        // RQ-2425: update the upstream-TLS-verification policy on the running proxy.
+        // The per-request handler reads `this.proxyConfig.allowInsecureCerts`, so
+        // mutating it here takes effect on the next request — no proxy restart.
+        this.setAllowInsecureCerts = (value) => {
+            if (this.proxyConfig) {
+                this.proxyConfig.allowInsecureCerts = !!value;
+            }
+        };
         /* NOT USEFUL */
         this.init_config = (config = {}) => {
             Object.keys(exports.MIDDLEWARE_TYPE).map((middleware_key) => {

--- a/dist/components/proxy-middleware/index.js
+++ b/dist/components/proxy-middleware/index.js
@@ -75,9 +75,13 @@ class ProxyMiddlewareManager {
             const is_detachable = true;
             const logger_middleware = new logger_middleware_1.default(this.config[exports.MIDDLEWARE_TYPE.LOGGER], this.loggerService);
             const idx = this.init_request_handler(async (ctx, callback) => {
+                var _a;
                 ctx.rq = new ctx_rq_namespace_1.default();
                 ctx.rq.set_original_request((0, proxy_ctx_helper_1.get_request_options)(ctx));
-                ctx.proxyToServerRequestOptions.rejectUnauthorized = false;
+                // RQ-2425: verify upstream TLS certificates by default. Only skip
+                // verification when the user has explicitly opted in (e.g. to reach a
+                // self-signed / internal upstream). Defaults to secure when unset.
+                ctx.proxyToServerRequestOptions.rejectUnauthorized = !((_a = this.proxyConfig) === null || _a === void 0 ? void 0 : _a.allowInsecureCerts);
                 // Figure out a way to enable/disable middleware dynamically
                 // instead of re-initing this again
                 const rules_middleware = new rules_middleware_1.default(this.config[exports.MIDDLEWARE_TYPE.RULES], ctx, this.rulesHelper);

--- a/dist/components/proxy-middleware/index.js
+++ b/dist/components/proxy-middleware/index.js
@@ -94,6 +94,7 @@ class ProxyMiddlewareManager {
                 // instead of re-initing this again
                 const rules_middleware = new rules_middleware_1.default(this.config[exports.MIDDLEWARE_TYPE.RULES], ctx, this.rulesHelper);
                 ctx.onError(async function (ctx, err, kind, callback) {
+                    var _a, _b;
                     // Should only modify response body & headers
                     ctx.rq_response_body = "" + kind + ": " + err, "utf8";
                     const { action_result_objs, continue_request } = await rules_middleware.on_response(ctx);
@@ -114,9 +115,31 @@ class ProxyMiddlewareManager {
                         }
                     }
                     else if (kind === "PROXY_TO_SERVER_REQUEST_ERROR") {
+                        const host = (0, proxy_ctx_helper_1.get_request_url)(ctx);
+                        // RQ-2425: upstream TLS cert verification failed (e.g. "Allow insecure
+                        // SSL" is OFF and the origin has an untrusted/expired/self-signed cert).
+                        // Serve a clear SSL error instead of a misleading ERR_NAME_NOT_RESOLVED.
+                        if ((0, handleUnreachableAddress_1.isCertificateError)(err)) {
+                            const { status, contentType, body, errorToken } = (0, handleUnreachableAddress_1.dataToServeCertErrorPage)(host, err === null || err === void 0 ? void 0 : err.code);
+                            ctx.proxyToClientResponse.writeHead(status, http_1.default.STATUS_CODES[status], {
+                                "Content-Type": contentType,
+                                "x-rq-error": errorToken,
+                            });
+                            ctx.proxyToClientResponse.end(body);
+                            ctx.rq.set_final_response({
+                                status_code: status,
+                                headers: { "Content-Type": contentType },
+                                body: body,
+                            });
+                            logger_middleware.send_network_log(ctx, rules_middleware.action_result_objs, requestly_core_1.CONSTANTS.REQUEST_STATE.COMPLETE);
+                            return;
+                        }
                         try {
-                            const host = (0, proxy_ctx_helper_1.get_request_url)(ctx);
-                            const isAddressUnreachable = await (0, handleUnreachableAddress_1.isAddressUnreachableError)(host);
+                            // Resolve against a clean hostname (headers.host minus any port), not
+                            // the full request URL — dns.lookup() can't parse a URL and would
+                            // otherwise report every upstream error as ENOTFOUND.
+                            const hostname = (((_b = (_a = ctx.clientToProxyRequest) === null || _a === void 0 ? void 0 : _a.headers) === null || _b === void 0 ? void 0 : _b.host) || "").split(":")[0];
+                            const isAddressUnreachable = await (0, handleUnreachableAddress_1.isAddressUnreachableError)(hostname);
                             if (isAddressUnreachable) {
                                 const { status, contentType, body } = (0, handleUnreachableAddress_1.dataToServeUnreachablePage)(host);
                                 ctx.proxyToClientResponse.writeHead(status, http_1.default.STATUS_CODES[status], {

--- a/dist/rq-proxy.d.ts
+++ b/dist/rq-proxy.d.ts
@@ -13,6 +13,7 @@ declare class RQProxy {
     globalState: State;
     constructor(proxyConfig: ProxyConfig, rulesDataSource: IRulesDataSource, loggerService: ILoggerService, initialGlobalState?: IInitialState);
     initProxy: (proxyConfig: ProxyConfig) => void;
+    setAllowInsecureCerts: (value: boolean) => void;
     doSomething: () => void;
 }
 export default RQProxy;

--- a/dist/rq-proxy.d.ts
+++ b/dist/rq-proxy.d.ts
@@ -11,6 +11,7 @@ declare class RQProxy {
     rulesHelper: RulesHelper;
     loggerService: ILoggerService;
     globalState: State;
+    private allowInsecureCerts?;
     constructor(proxyConfig: ProxyConfig, rulesDataSource: IRulesDataSource, loggerService: ILoggerService, initialGlobalState?: IInitialState);
     initProxy: (proxyConfig: ProxyConfig) => void;
     setAllowInsecureCerts: (value: boolean) => void;

--- a/dist/rq-proxy.js
+++ b/dist/rq-proxy.js
@@ -47,6 +47,11 @@ class RQProxy {
             });
             //
         };
+        // RQ-2425: live-update upstream TLS verification without restarting the proxy.
+        this.setAllowInsecureCerts = (value) => {
+            var _a, _b;
+            (_b = (_a = this.proxyMiddlewareManager) === null || _a === void 0 ? void 0 : _a.setAllowInsecureCerts) === null || _b === void 0 ? void 0 : _b.call(_a, value);
+        };
         this.doSomething = () => {
             console.log("do something");
         };

--- a/dist/rq-proxy.js
+++ b/dist/rq-proxy.js
@@ -24,6 +24,7 @@ class RQProxy {
                 sslCaDir: proxyConfig.certPath,
                 host: "0.0.0.0",
             }, (err) => {
+                var _a, _b;
                 console.log("Proxy Listen");
                 if (err) {
                     console.log(err);
@@ -32,6 +33,10 @@ class RQProxy {
                     console.log("Proxy Started");
                     this.proxyMiddlewareManager = new proxy_middleware_1.default(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null);
                     this.proxyMiddlewareManager.init();
+                    // Replay a toggle that was set before the manager existed.
+                    if (this.allowInsecureCerts !== undefined) {
+                        (_b = (_a = this.proxyMiddlewareManager).setAllowInsecureCerts) === null || _b === void 0 ? void 0 : _b.call(_a, this.allowInsecureCerts);
+                    }
                 }
             });
             // For Testing //
@@ -48,9 +53,12 @@ class RQProxy {
             //
         };
         // RQ-2425: live-update upstream TLS verification without restarting the proxy.
+        // Remembers the value so it survives even if set before the middleware manager
+        // is ready (replayed in initProxy once the manager is created).
         this.setAllowInsecureCerts = (value) => {
             var _a, _b;
-            (_b = (_a = this.proxyMiddlewareManager) === null || _a === void 0 ? void 0 : _a.setAllowInsecureCerts) === null || _b === void 0 ? void 0 : _b.call(_a, value);
+            this.allowInsecureCerts = !!value;
+            (_b = (_a = this.proxyMiddlewareManager) === null || _a === void 0 ? void 0 : _a.setAllowInsecureCerts) === null || _b === void 0 ? void 0 : _b.call(_a, this.allowInsecureCerts);
         };
         this.doSomething = () => {
             console.log("do something");

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -4,6 +4,7 @@ export interface ProxyConfig {
     certPath: String;
     rootCertPath: String;
     onCARegenerated?: Function;
+    allowInsecureCerts?: boolean;
 }
 export interface Rule {
     id: string;

--- a/src/components/proxy-middleware/helpers/handleUnreachableAddress.js
+++ b/src/components/proxy-middleware/helpers/handleUnreachableAddress.js
@@ -1,5 +1,16 @@
 import dns from 'dns';
 
+// Escape request-derived values before embedding them into the HTML error pages
+// so a crafted host/URL can't inject markup/script (reflected injection).
+function escapeHtml(value) {
+    return String(value === undefined || value === null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 export function isAddressUnreachableError(host) {
     return new Promise((resolve, reject) => {
         dns.lookup(host, (err, address) => {
@@ -60,6 +71,8 @@ export function certErrorToken(code) {
 
 export function dataToServeCertErrorPage(host, code) {
     const token = certErrorToken(code);
+    const safeHost = escapeHtml(host);
+    const safeCode = escapeHtml(code);
     return {
         status: 502,
         contentType: 'text/html',
@@ -119,7 +132,7 @@ export function dataToServeCertErrorPage(host, code) {
     <div class="container">
         <div class="sad-face">:(</div>
         <h1>This site's SSL certificate isn't trusted</h1>
-        <p>Requestly couldn't verify the TLS certificate of <strong>${host}</strong>${code ? ` (<code>${code}</code>)` : ''}.</p>
+        <p>Requestly couldn't verify the TLS certificate of <strong>${safeHost}</strong>${code ? ` (<code>${safeCode}</code>)` : ''}.</p>
         <p>If you trust this host, enable <strong>“Allow insecure SSL in proxy interceptor”</strong> in Requestly desktop settings and reload.</p>
         <p><strong>${token}</strong></p>
     </div>
@@ -182,7 +195,7 @@ export function dataToServeUnreachablePage(host) {
     <div class="container">
         <div class="sad-face">:(</div>
         <h1>This site can’t be reached</h1>
-        <p>The webpage at <strong>${host}/</strong> might be temporarily down or it may have moved permanently to a new web address.</p>
+        <p>The webpage at <strong>${escapeHtml(host)}/</strong> might be temporarily down or it may have moved permanently to a new web address.</p>
         <p><strong>ERR_NAME_NOT_RESOLVED</strong></p>
     </div>
 </body>

--- a/src/components/proxy-middleware/helpers/handleUnreachableAddress.js
+++ b/src/components/proxy-middleware/helpers/handleUnreachableAddress.js
@@ -7,13 +7,126 @@ export function isAddressUnreachableError(host) {
                 if (err.code === 'ENOTFOUND') {
                     resolve(true);
                 } else {
-                    reject(err); 
+                    reject(err);
                 }
             } else {
-                resolve(false); 
+                resolve(false);
             }
         });
     });
+}
+
+// RQ-2425: upstream TLS certificate verification failures. These surface when
+// "Allow insecure SSL in proxy interceptor" is OFF (the default) and the origin
+// presents an untrusted/expired/self-signed cert. Without this, such failures
+// were misreported as ERR_NAME_NOT_RESOLVED, which is confusing.
+const TLS_CERT_ERROR_CODES = new Set([
+    'CERT_HAS_EXPIRED',
+    'CERT_NOT_YET_VALID',
+    'DEPTH_ZERO_SELF_SIGNED_CERT',
+    'SELF_SIGNED_CERT_IN_CHAIN',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+    'UNABLE_TO_GET_ISSUER_CERT',
+    'CERT_UNTRUSTED',
+    'CERT_REVOKED',
+    'CERT_REJECTED',
+    'HOSTNAME_MISMATCH',
+    'ERR_TLS_CERT_ALTNAME_INVALID',
+]);
+
+export function isCertificateError(err) {
+    if (!err) return false;
+    if (err.code && TLS_CERT_ERROR_CODES.has(err.code)) return true;
+    const message = String((err && (err.message || err.reason)) || '');
+    return /\bcertificate\b/i.test(message) || /ERR_TLS_CERT/i.test(message);
+}
+
+// Maps a Node/OpenSSL cert error code to a Chrome-style token users recognise.
+export function certErrorToken(code) {
+    switch (code) {
+        case 'CERT_HAS_EXPIRED':
+        case 'CERT_NOT_YET_VALID':
+            return 'ERR_CERT_DATE_INVALID';
+        case 'HOSTNAME_MISMATCH':
+        case 'ERR_TLS_CERT_ALTNAME_INVALID':
+            return 'ERR_CERT_COMMON_NAME_INVALID';
+        case 'CERT_REVOKED':
+            return 'ERR_CERT_REVOKED';
+        default:
+            return 'ERR_CERT_AUTHORITY_INVALID';
+    }
+}
+
+export function dataToServeCertErrorPage(host, code) {
+    const token = certErrorToken(code);
+    return {
+        status: 502,
+        contentType: 'text/html',
+        errorToken: token,
+        body: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>${token}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+    <style>
+        body {
+            background-color: #f2f2f2;
+            color: #333;
+            font-family: 'Roboto', sans-serif;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 100px auto;
+            padding: 20px;
+            text-align: center;
+        }
+        .sad-face {
+            font-size: 80px;
+            margin-bottom: 20px;
+        }
+        h1 {
+            font-size: 24px;
+            font-weight: normal;
+            margin-bottom: 10px;
+        }
+        p {
+            font-size: 16px;
+            color: #666;
+        }
+        code {
+            background: #e8e8e8;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+        @media (max-width: 600px) {
+            .container {
+                margin-top: 50px;
+                padding: 10px;
+            }
+            .sad-face {
+                font-size: 60px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="sad-face">:(</div>
+        <h1>This site's SSL certificate isn't trusted</h1>
+        <p>Requestly couldn't verify the TLS certificate of <strong>${host}</strong>${code ? ` (<code>${code}</code>)` : ''}.</p>
+        <p>If you trust this host, enable <strong>“Allow insecure SSL in proxy interceptor”</strong> in Requestly desktop settings and reload.</p>
+        <p><strong>${token}</strong></p>
+    </div>
+</body>
+</html>
+        `.trim()
+    };
 }
 
 export function dataToServeUnreachablePage(host) {

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -126,7 +126,10 @@ class ProxyMiddlewareManager {
     const idx = this.init_request_handler(async (ctx, callback) => {
       ctx.rq = new CtxRQNamespace();
       ctx.rq.set_original_request(get_request_options(ctx));
-      ctx.proxyToServerRequestOptions.rejectUnauthorized = false;
+      // RQ-2425: verify upstream TLS certificates by default. Only skip
+      // verification when the user has explicitly opted in (e.g. to reach a
+      // self-signed / internal upstream). Defaults to secure when unset.
+      ctx.proxyToServerRequestOptions.rejectUnauthorized = !this.proxyConfig?.allowInsecureCerts;
       // Figure out a way to enable/disable middleware dynamically
       // instead of re-initing this again
       const rules_middleware = new RulesMiddleware(

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -210,8 +210,15 @@ class ProxyMiddlewareManager {
           try {
             // Resolve against a clean hostname (headers.host minus any port), not
             // the full request URL — dns.lookup() can't parse a URL and would
-            // otherwise report every upstream error as ENOTFOUND.
-            const hostname = (ctx.clientToProxyRequest?.headers?.host || "").split(":")[0];
+            // otherwise report every upstream error as ENOTFOUND. Parse via URL so
+            // IPv6 literals (e.g. "[::1]:443") are handled correctly, not split on ":".
+            const rawHost = ctx.clientToProxyRequest?.headers?.host || "";
+            let hostname = rawHost;
+            try {
+              hostname = new URL(`http://${rawHost}`).hostname.replace(/^\[|\]$/g, "");
+            } catch (e) {
+              hostname = rawHost.replace(/:\d+$/, "");
+            }
             const isAddressUnreachable = await isAddressUnreachableError(hostname);
             if (isAddressUnreachable) {
               const { status, contentType, body } = dataToServeUnreachablePage(host);

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -61,6 +61,15 @@ class ProxyMiddlewareManager {
     // this.sslProxyingManager = new SSLProxyingManager(sslConfigFetcher);
   }
 
+  // RQ-2425: update the upstream-TLS-verification policy on the running proxy.
+  // The per-request handler reads `this.proxyConfig.allowInsecureCerts`, so
+  // mutating it here takes effect on the next request — no proxy restart.
+  setAllowInsecureCerts = (value) => {
+    if (this.proxyConfig) {
+      this.proxyConfig.allowInsecureCerts = !!value;
+    }
+  };
+
   /* NOT USEFUL */
   init_config = (config = {}) => {
     Object.keys(MIDDLEWARE_TYPE).map((middleware_key) => {

--- a/src/components/proxy-middleware/index.js
+++ b/src/components/proxy-middleware/index.js
@@ -21,7 +21,7 @@ import CtxRQNamespace from "./helpers/ctx_rq_namespace";
 import { bodyParser, getContentType } from "./helpers/http_helpers";
 import { RQ_INTERCEPTED_CONTENT_TYPES_REGEX, RULE_ACTION } from "./constants";
 import { CONSTANTS as GLOBAL_CONSTANTS } from "@requestly/requestly-core";
-import { dataToServeUnreachablePage, isAddressUnreachableError } from "./helpers/handleUnreachableAddress";
+import { dataToServeUnreachablePage, isAddressUnreachableError, isCertificateError, dataToServeCertErrorPage } from "./helpers/handleUnreachableAddress";
 // import SSLProxyingConfigFetcher from "renderer/lib/fetcher/ssl-proxying-config-fetcher";
 // import SSLProxyingManager from "../ssl-proxying/ssl-proxying-manager";
 
@@ -178,9 +178,41 @@ class ProxyMiddlewareManager {
             )
           } 
         } else if (kind === "PROXY_TO_SERVER_REQUEST_ERROR") {
+          const host = get_request_url(ctx);
+
+          // RQ-2425: upstream TLS cert verification failed (e.g. "Allow insecure
+          // SSL" is OFF and the origin has an untrusted/expired/self-signed cert).
+          // Serve a clear SSL error instead of a misleading ERR_NAME_NOT_RESOLVED.
+          if (isCertificateError(err)) {
+            const { status, contentType, body, errorToken } = dataToServeCertErrorPage(host, err?.code);
+            ctx.proxyToClientResponse.writeHead(
+              status,
+              http.STATUS_CODES[status],
+              {
+                "Content-Type": contentType,
+                "x-rq-error": errorToken,
+              }
+            );
+            ctx.proxyToClientResponse.end(body);
+            ctx.rq.set_final_response({
+              status_code: status,
+              headers: { "Content-Type": contentType },
+              body: body,
+            });
+            logger_middleware.send_network_log(
+              ctx,
+              rules_middleware.action_result_objs,
+              GLOBAL_CONSTANTS.REQUEST_STATE.COMPLETE
+            );
+            return;
+          }
+
           try {
-            const host = get_request_url(ctx);
-            const isAddressUnreachable = await isAddressUnreachableError(host);
+            // Resolve against a clean hostname (headers.host minus any port), not
+            // the full request URL — dns.lookup() can't parse a URL and would
+            // otherwise report every upstream error as ENOTFOUND.
+            const hostname = (ctx.clientToProxyRequest?.headers?.host || "").split(":")[0];
+            const isAddressUnreachable = await isAddressUnreachableError(hostname);
             if (isAddressUnreachable) {
               const { status, contentType, body } = dataToServeUnreachablePage(host);
               ctx.proxyToClientResponse.writeHead(

--- a/src/rq-proxy.ts
+++ b/src/rq-proxy.ts
@@ -16,6 +16,10 @@ class RQProxy {
     loggerService: ILoggerService;
     globalState: State;
 
+    // RQ-2425: remembered so a toggle set before the middleware manager exists
+    // (early in startup) isn't lost — it's replayed once the manager is created.
+    private allowInsecureCerts?: boolean;
+
     constructor(
         proxyConfig: ProxyConfig, 
         rulesDataSource: IRulesDataSource, 
@@ -52,6 +56,10 @@ class RQProxy {
                     console.log("Proxy Started");
                     this.proxyMiddlewareManager = new ProxyMiddlewareManager(this.proxy, proxyConfig, this.rulesHelper, this.loggerService, null);
                     this.proxyMiddlewareManager.init();
+                    // Replay a toggle that was set before the manager existed.
+                    if (this.allowInsecureCerts !== undefined) {
+                        this.proxyMiddlewareManager.setAllowInsecureCerts?.(this.allowInsecureCerts);
+                    }
                 }
             }
         );
@@ -72,8 +80,11 @@ class RQProxy {
     }
 
     // RQ-2425: live-update upstream TLS verification without restarting the proxy.
+    // Remembers the value so it survives even if set before the middleware manager
+    // is ready (replayed in initProxy once the manager is created).
     setAllowInsecureCerts = (value: boolean) => {
-        this.proxyMiddlewareManager?.setAllowInsecureCerts?.(value);
+        this.allowInsecureCerts = !!value;
+        this.proxyMiddlewareManager?.setAllowInsecureCerts?.(this.allowInsecureCerts);
     }
 
     doSomething = () => {

--- a/src/rq-proxy.ts
+++ b/src/rq-proxy.ts
@@ -71,6 +71,11 @@ class RQProxy {
         //
     }
 
+    // RQ-2425: live-update upstream TLS verification without restarting the proxy.
+    setAllowInsecureCerts = (value: boolean) => {
+        this.proxyMiddlewareManager?.setAllowInsecureCerts?.(value);
+    }
+
     doSomething = () => {
         console.log("do something");
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,9 @@ export interface ProxyConfig {
     certPath: String;
     rootCertPath: String;
     onCARegenerated?: Function;
+    // RQ-2425: when true, the proxy skips upstream TLS certificate verification
+    // (for self-signed / internal upstreams). Defaults to false (verify) when unset.
+    allowInsecureCerts?: boolean;
 }
 
 export interface Rule {


### PR DESCRIPTION
Security fix for **RQ-2425** (Critical). Part of a 3-repo change (proxy + desktop-app + interceptor web app) — should merge together.

## What
- Replace the hardcoded `rejectUnauthorized = false` with `!proxyConfig.allowInsecureCerts` — **verify upstream TLS by default**.
- Add `setAllowInsecureCerts()` live setter on RQProxy/ProxyMiddlewareManager so the desktop toggle applies to the running proxy **without a restart**.
- On upstream cert rejection, serve a clear SSL error page (`CERT_HAS_EXPIRED`→`ERR_CERT_DATE_INVALID`, self-signed→`ERR_CERT_AUTHORITY_INVALID`, …) instead of a misleading `ERR_NAME_NOT_RESOLVED`; fix the DNS-unreachable check to use a clean hostname.

## Verified
End-to-end through the running proxy: bad-cert hosts (expired/self-signed) fail with default-on verification (502) and load when the toggle is on; valid certs unaffected; toggle flips live with no restart.

⚠️ Draft — pending review. Pairs with the desktop-app + interceptor PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime control to disable upstream SSL/TLS certificate verification for compatibility with self-signed or internal certificates.
  * Introduced dedicated error pages for certificate validation failures with diagnostic tokens.

* **Bug Fixes**
  * Improved error handling to properly distinguish between certificate failures and unreachable-address errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->